### PR TITLE
chore: Added polar env vars to turbo.json

### DIFF
--- a/turbo.json
+++ b/turbo.json
@@ -15,6 +15,7 @@
         "POLAR_SERVER_MODE",
         "POLAR_ACCESS_TOKEN",
         "POLAR_WEBHOOK_SECRET",
+        "POLAR_ORGANIZATION_ID",
         "VITE_NGROK_URL"
       ],
       "inputs": ["$TURBO_DEFAULT$", ".env"],
@@ -52,7 +53,8 @@
       "outputs": []
     },
     "db:generate": {
-      "cache": false
+      "cache": false,
+      "outputs": ["generated/**"]
     },
     "db:migrate": {
       "cache": false,


### PR DESCRIPTION

Vercel build warnings:

```
WARNING  finished with warnings
Warning - the following environment variables are set on your Vercel project, but missing from "turbo.json". These variables WILL NOT be available to your application and may cause your build to fail. Learn more at https://turborepo.com/docs/crafting-your-repository/using-environment-variables#platform-environment-variables
[warn] @bklit/db#build
[warn]   - POLAR_ORGANIZATION_ID 
[warn] @bklit/dashboard#build
[warn]   - POLAR_ORGANIZATION_ID 
```