### PR TITLE
feat(dashboard): Improved presentation of creation routes

### DIFF
--- a/apps/dashboard/src/app/(dashboard)/[organizationId]/projects/create/page.tsx
+++ b/apps/dashboard/src/app/(dashboard)/[organizationId]/projects/create/page.tsx
@@ -1,5 +1,26 @@
+import { Card, CardContent } from "@bklit/ui/components/card";
+import type { Metadata } from "next";
 import { AddProjectForm } from "@/components/forms/add-project-form";
+import { PageHeader } from "@/components/header/page-header";
+
+export const metadata: Metadata = {
+  title: "Create Project | Bklit",
+};
 
 export default function CreateProjectPage() {
-  return <AddProjectForm />;
+  return (
+    <>
+      <PageHeader
+        title="Create Project"
+        description="Create a new project for your organization."
+      />
+      <div className="container mx-auto py-6 px-4 flex gap-4">
+        <Card className="w-full max-w-2xl">
+          <CardContent>
+            <AddProjectForm />
+          </CardContent>
+        </Card>
+      </div>
+    </>
+  );
 }

--- a/apps/dashboard/src/app/(dashboard)/organizations/create/page.tsx
+++ b/apps/dashboard/src/app/(dashboard)/organizations/create/page.tsx
@@ -1,5 +1,26 @@
+import { Card, CardContent } from "@bklit/ui/components/card";
+import type { Metadata } from "next";
 import { AddOrganizationForm } from "@/components/forms/add-organization-form";
+import { PageHeader } from "@/components/header/page-header";
+
+export const metadata: Metadata = {
+  title: "Create Workspace | Bklit",
+};
 
 export default function CreateOrganizationPage() {
-  return <AddOrganizationForm />;
+  return (
+    <>
+      <PageHeader
+        title="Create Workspace"
+        description="Create your new workspace"
+      />
+      <div className="container mx-auto py-6 px-4 flex gap-4">
+        <Card className="w-full max-w-2xl">
+          <CardContent>
+            <AddOrganizationForm />
+          </CardContent>
+        </Card>
+      </div>
+    </>
+  );
 }


### PR DESCRIPTION
Routes now look presentable:
- `/organizations/create`
- `[organizationId]/projects/create`