### PR TITLE
fix: correct search dialog positioning to prevent top cutoff

### DIFF
--- a/packages/ui/src/components/search-dialog.tsx
+++ b/packages/ui/src/components/search-dialog.tsx
@@ -55,7 +55,7 @@ function SearchDialogContent({
       <DialogPrimitive.Content
         data-slot="dialog-content"
         className={cn(
-          "bg-card data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 fixed top-[15%] left-[50%] z-50 grid w-full max-w-[calc(100%-2rem)] translate-x-[-50%] translate-y-[-50%] gap-4 rounded-lg border p-2 shadow-lg duration-200 sm:max-w-lg",
+          "bg-card data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 fixed top-[20%] left-[50%] z-50 grid w-full max-w-[calc(100%-2rem)] translate-x-[-50%] gap-4 rounded-lg border p-2 shadow-lg duration-200 sm:max-w-lg",
           className,
         )}
         {...props}


### PR DESCRIPTION
## Problem
The search dialog was being positioned with `top-[15%]` and `translate-y-[-50%]`, which shifted it up by 50% of its own height. This caused the top portion of the dialog to be cut off and positioned above the viewport.

## Solution
- Removed `translate-y-[-50%]` from the dialog positioning
- Adjusted `top-[15%]` to `top-[20%]` for better vertical placement

## Changes
- `packages/ui/src/components/search-dialog.tsx` - Fixed dialog content positioning

## Before
Dialog top portion cut off above viewport

## After
Dialog fully visible with proper spacing

<img width="2911" height="900" alt="Search Bar PR" src="https://github.com/user-attachments/assets/f42dac90-f878-4650-8171-86030a886e49" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Optimized search dialog vertical positioning and centering behavior to improve visual alignment and layout consistency.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->